### PR TITLE
add comma-spacing rule with defaults

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,13 @@ module.exports = {
             2,
             "only-multiline"
         ],
+        "comma-spacing": [
+            2,
+            {
+                "before": false,
+                "after": true
+            }
+        ],
         "comma-style": [
             2,
             "last"


### PR DESCRIPTION
Work on a private repo showed that we should enable this. Enabling this rule causes the following code to have an error, which it did not previously:

```js
// error from next line
function funguy(a,b) {
    console.log(a, b)
}

funguy()
```