### PR TITLE
enable wrap-iife

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,6 +146,10 @@ module.exports = {
                 "requireStringLiterals": true
             }
         ],
-        "vars-on-top": 2
+        "vars-on-top": 2,
+        "wrap-iife": [
+            2,
+            "inside"
+        ]
     }
 }


### PR DESCRIPTION
Rationale: invocation at the end without some indication at the beginning of a function makes it hard to know that a function is immediately invoked. This is confusing in the case of assignment and confusing in the case of really large IIFEs, which is common in front-end web development.