### PR TITLE
Enable no-implicit-globals

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,6 +120,7 @@ module.exports = {
             "single",
             "avoid-escape"
         ],
+        "radix": 2,
         "semi": [
             2,
             "never"

--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ module.exports = {
             2,
             "functions"
         ],
+        "no-implicit-globals": 2,
         "no-lonely-if": 2,
         "no-multi-spaces": 2,
         "no-multi-str": 2,
@@ -120,7 +121,6 @@ module.exports = {
             "single",
             "avoid-escape"
         ],
-        "radix": 2,
         "semi": [
             2,
             "never"


### PR DESCRIPTION
This avoids accidentally adding things to global (`window`) scope in browser scripts and doesn't affect node environments.

http://eslint.org/docs/rules/no-implicit-globals