### PR TITLE
use no-restricted-syntax to avoid parseInt errors with map

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,6 +87,13 @@ module.exports = {
             2,
             "Promise"
         ],
+        "no-restricted-syntax": [
+            "error",
+            {
+                "selector": "CallExpression[callee.name!='parseInt'] > Identifier[name='parseInt']",
+                "message": "Call parseInt directly to guarantee radix param is not incorrectly provided"
+            }
+        ],
         "no-return-assign": [
             2,
             "always"

--- a/package.json
+++ b/package.json
@@ -10,11 +10,11 @@
   "author": "Scoop Technologies Inc",
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^3.17.0",
+    "eslint": "^3.19.0",
     "eslint-plugin-dependencies": "^2.2.0"
   },
   "peerDependencies": {
-    "eslint": "^3.17.0",
+    "eslint": "^3.19.0",
     "eslint-plugin-dependencies": "^2.2.0"
   }
 }

--- a/test/fixtures/fails/parseIntWithMap.js
+++ b/test/fixtures/fails/parseIntWithMap.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const arr = ['11', '3']
+
+console.log(arr.map(parseInt))

--- a/test/fixtures/passes/safeParseInt.js
+++ b/test/fixtures/passes/safeParseInt.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const arr = ['11', '3']
+
+console.log(arr.map(function(n) {
+    return parseInt(n)
+}))
+
+
+parseInt(5, 10)
+
+// not really safe but eslint doesn't support catching this
+let fun = parseInt
+console.log(arr.map(fun))


### PR DESCRIPTION
This introduces a custom syntax restriction to avoid a class of errors using `parseInt` with functions like `Array#map`. For example:

```
> const arr = ['11', '3']
> console.log(arr.map(parseInt))
[ 11, NaN ]
```

This is caused by `map` invoking `parseInt` with a second parameter that is unexpected.

Related ESLint issue I filed: https://github.com/eslint/eslint/issues/8214

This also bumps the ESLint version since the documented rule didn't seem to work with 3.17

---

References that helped me do this:

- [`no-restricted-syntax`](http://eslint.org/docs/rules/no-restricted-syntax)
- [ESLint guide to selectors](http://eslint.org/docs/developer-guide/selectors)
- [ESLint parser](http://eslint.org/parser/) to see how code is parsed
- [esprima (not espree) query tool](https://estools.github.io/esquery/) -- not quite version of parser that ESLint uses as far as I understand but helpful
