### PR TITLE
New rule for spacing after unary operators

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,12 @@ module.exports = {
             "never"
         ],
         "space-infix-ops": 2,
+        "space-unary-ops": [
+            2, {
+            "words": true,
+            "nonwords": false
+            }
+        ],
         "spaced-comment": 2,
         "strict": [
             2,

--- a/test/fixtures/fails/unarySpaceNonword.js
+++ b/test/fixtures/fails/unarySpaceNonword.js
@@ -1,0 +1,3 @@
+'use strict'
+
+! true

--- a/test/fixtures/fails/unarySpaceWord.js
+++ b/test/fixtures/fails/unarySpaceWord.js
@@ -1,0 +1,3 @@
+'use strict'
+
+new[]

--- a/test/fixtures/passes/unarySpaceNonword.js
+++ b/test/fixtures/passes/unarySpaceNonword.js
@@ -1,0 +1,3 @@
+'use strict'
+
+!true

--- a/test/fixtures/passes/unarySpaceWord.js
+++ b/test/fixtures/passes/unarySpaceWord.js
@@ -1,0 +1,3 @@
+'use strict'
+
+new []


### PR DESCRIPTION
Resolves https://github.com/TakeScoop/eslint-config-scoop/issues/17

Prefers no spaces after nonword operators, and spaces after word operators.

Valid examples:
`!true`
`new []`

Invalid examples:
`! true`
`new[]`