### PR TITLE
Install publish2npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 .gitignore
 .git
+circle.yml
 node_modules/
 test/

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,8 @@
+dependencies:
+  pre:
+    - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+deployment:
+  npm:
+    branch: master
+    commands:
+      - $(npm bin)/publish2npm

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 dependencies:
   pre:
-    - echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+    - echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' > .npmrc
 deployment:
   npm:
     branch: master

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
   "author": "Scoop Technologies Inc",
   "license": "MIT",
   "devDependencies": {
+    "@scoop/publish2npm": "^0.1.3",
     "eslint": "^3.19.0",
-    "eslint-plugin-dependencies": "^2.2.0"
+    "eslint-plugin-dependencies": "^2.4.0"
   },
   "peerDependencies": {
     "eslint": "^3.19.0",
-    "eslint-plugin-dependencies": "^2.2.0"
+    "eslint-plugin-dependencies": "^2.4.0"
   }
 }


### PR DESCRIPTION
Installs publish2npm for deployment use in CircleCI, and also updates version of `eslint-plugin-dependencies` to `2.4.0` (to match other usage).