### PR TITLE
Add implicit dependencies rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 To use:
 
 ```sh  
-npm install --save-dev eslint@4 eslint-plugin-dependencies@2 @scoop/eslint-config-scoop@latest
+npm install --save-dev eslint@4 eslint-plugin-dependencies@2 eslint-plugin-implicit-dependencies@1 @scoop/eslint-config-scoop@latest
 ```
 
 Then, add an `.eslintrc.json` file with the following:

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ module.exports = {
     },
     "extends": "eslint:recommended",
     "plugins": [
-        "dependencies"
+        "dependencies",
+        "implicit-dependencies"
     ],
     "rules": {
         "dependencies/case-sensitive": 2,
@@ -47,6 +48,14 @@ module.exports = {
         "dot-notation": 2,
         "eol-last": 2,
         "eqeqeq": 2,
+        "implicit-dependencies/no-implicit": [
+            "error",
+            {
+                "peer": true,
+                "dev": true,
+                "optional": true
+            }
+        ],
         "indent": [
             2,
             4,

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "peerDependencies": {
     "eslint": "^4.9.0",
     "eslint-plugin-dependencies": "^2.2.0"
+  },
+  "dependencies": {
+    "eslint-plugin-implicit-dependencies": "^1.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,9 +19,7 @@
   },
   "peerDependencies": {
     "eslint": "^4.9.0",
-    "eslint-plugin-dependencies": "^2.2.0"
-  },
-  "dependencies": {
+    "eslint-plugin-dependencies": "^2.2.0",
     "eslint-plugin-implicit-dependencies": "^1.0.4"
   }
 }


### PR DESCRIPTION
Detects when a module has been required that is not listed as a dependency in the project's package.json.

This helps prevent accidentally depending on a module that is present in `node_modules` as a result of being installed further down the dependency tree, but is not listed as an explicit dependency in the project.

Added `eslint-plugin-implicit-dependencies` as a peer dependency and updated README to add installation step for new package.