### PR TITLE
Do not allow multiple empty lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,14 @@ module.exports = {
         "no-implicit-globals": 2,
         "no-lonely-if": 2,
         "no-multi-spaces": 2,
+        "no-multiple-empty-lines": [
+            2, 
+            {
+                "max": 1,
+                "maxEOF": 0,
+                "maxBOF": 0
+            }
+        ],
         "no-multi-str": 2,
         "no-new-object": 2,
         "no-restricted-globals": [

--- a/test/fixtures/passes/safeParseInt.js
+++ b/test/fixtures/passes/safeParseInt.js
@@ -6,7 +6,6 @@ console.log(arr.map(function(n) {
     return parseInt(n)
 }))
 
-
 parseInt(5, 10)
 
 // not really safe but eslint doesn't support catching this


### PR DESCRIPTION
https://eslint.org/docs/rules/no-multiple-empty-lines#disallow-multiple-empty-lines-no-multiple-empty-lines

Changes: 
- allow a maximum of ONE empty line
- end of file should not be padded with empty lines
- beginning of file should not be padding with empty lines

TODO:
- [x] ~~test rule changes against api repo~~


