### PR TITLE
Enforce directive padding (i.e. 'use strict' should be followed by empty line)

### DIFF
--- a/index.js
+++ b/index.js
@@ -143,6 +143,11 @@ module.exports = {
             "never"
         ],
         "padded-blocks": 0,
+        "padding-line-between-statements": [
+            2,
+            { "blankLine": "always", "prev": "directive", "next": "*" },
+            { "blankLine": "any", "prev": "directive", next: "directive" }
+        ],
         "prefer-const": 2,
         "quotes": [
             2,

--- a/test/fixtures/fails/useStrictUnpadded.js
+++ b/test/fixtures/fails/useStrictUnpadded.js
@@ -1,0 +1,3 @@
+'use strict'
+const x = 10
+console.log(x)

--- a/test/tests/index.js
+++ b/test/tests/index.js
@@ -61,6 +61,11 @@ describe('testing eslint configuration', function() {
                 line: 3
             },
             {
+                filename: 'useStrictUnpadded.js',
+                rulename: 'padding-line-between-statements',
+                line: 2
+            },
+            {
                 filename: 'usingVar.js',
                 rulename: 'no-var',
                 line: 3


### PR DESCRIPTION
@andrewtamura from our discussion. This matches our convention. The last object in the array means that rule takes precedence if you need to combine multiple directives (we don't have a use case but figured I'd be complete). This actually comes from the docs: https://eslint.org/docs/rules/padding-line-between-statements