### PR TITLE
Ecmaversion 2018 and enforce space between async keyword and arrow function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,10 @@ version: 2
 jobs:
   build:
     docker:
+      # Node.js version should be the oldest LTS release
+      # that is still in maintenance in order to
+      # stay compatible with as many apps as possible that
+      # are using LTS releases appropriately.
       - image: circleci/node:8.16.0
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:6.16.0
+      - image: circleci/node:8.16.0
     steps:
       - checkout
       - run: npm install

--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ module.exports = {
         "node": true
     },
     "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 2018
+    },
     "plugins": [
         "dependencies",
         "implicit-dependencies"
@@ -163,7 +166,11 @@ module.exports = {
         "space-before-blocks": 2,
         "space-before-function-paren": [
             2,
-            "never"
+            {
+                "anonymous": "never",
+                "named": "never",
+                "asyncArrow": "always"
+            }
         ],
         "space-in-parens": [
             2,

--- a/test/fixtures/fails/noSpaceAfterAsyncFatArrow.js
+++ b/test/fixtures/fails/noSpaceAfterAsyncFatArrow.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const myFunc = async() => 'scott'
+
+console.log(myFunc)

--- a/test/fixtures/fails/tooManySpacesAfterAsync.js
+++ b/test/fixtures/fails/tooManySpacesAfterAsync.js
@@ -1,0 +1,7 @@
+'use strict'
+
+async     function myAwesomeFunction() {
+    console.log('dog')
+}
+
+myAwesomeFunction()

--- a/test/fixtures/passes/functionSpacing.js
+++ b/test/fixtures/passes/functionSpacing.js
@@ -1,0 +1,21 @@
+'use strict'
+
+function x() {
+    console.log(true)
+}
+
+x()
+
+function y(fn) {
+    fn()
+}
+
+y(function() {
+    console.log('z')
+})
+
+const a = async () => true
+a()
+
+const b = () => true
+b()

--- a/test/tests/index.js
+++ b/test/tests/index.js
@@ -36,6 +36,11 @@ describe('testing eslint configuration', function() {
                 line: [11, 12, 13]
             },
             {
+                filename: 'noSpaceAfterAsyncFatArrow.js',
+                rulename: 'space-before-function-paren',
+                line: 3
+            },
+            {
                 filename: 'parseIntWithMap.js',
                 rulename: 'no-restricted-syntax',
                 line: 5
@@ -53,6 +58,11 @@ describe('testing eslint configuration', function() {
             {
                 filename: 'shouldPreferConst.js',
                 rulename: 'prefer-const',
+                line: 3
+            },
+            {
+                filename: 'tooManySpacesAfterAsync.js',
+                rulename: 'no-multi-spaces',
                 line: 3
             },
             {
@@ -104,7 +114,7 @@ describe('testing eslint configuration', function() {
                 const filepath = path.join(fixturesDirectory, '/fails', test.filename)
                 const report = engine.executeOnFiles([filepath])
             
-                expect(report.errorCount).to.be.at.least(1)
+                expect(report.errorCount, 'ESLint error count').to.be.at.least(1)
             
                 const linesWithFailures = castArray(test.line)
                 const rulesThisCanViolate = castArray(test.rulename)


### PR DESCRIPTION
Fixes #35. This entailed further configuration of new-ish settings for `space-before-function-paren`. To support arrow syntax we need to bump to ecmaVersion=2018 which is probably time. This is equivalent roughly to node 8 from what I can tell, which is the oldest LTS presently.