### PR TITLE
Disallow multiline implicit return for arrow functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,10 @@ module.exports = {
         "dot-notation": 2,
         "eol-last": 2,
         "eqeqeq": 2,
+        "implicit-arrow-linebreak": [
+            2,
+            "beside"
+        ],
         "implicit-dependencies/no-implicit": [
             2,
             {

--- a/test/fixtures/fails/arrowReturnNewLine.js
+++ b/test/fixtures/fails/arrowReturnNewLine.js
@@ -1,0 +1,16 @@
+'use strict'
+
+function map() {
+    // no op
+}
+
+function a() {
+    return map([6, 3], (daysSince) => 
+        this.do({
+            x: 'x',
+            daysAgo: daysSince
+        })
+    )
+}
+
+a()

--- a/test/fixtures/passes/arrowReturns.js
+++ b/test/fixtures/passes/arrowReturns.js
@@ -1,0 +1,33 @@
+'use strict'
+
+function map() {
+    // no op
+}
+
+function a() {
+    return map([6, 3], (daysSince) => {
+        return this.do({
+            x: 'x',
+            daysAgo: daysSince
+        })
+    })
+}
+
+a()
+
+function b() {
+    return map([6, 3], (daysSince) => this.do({ x: 'x' }))
+}
+
+b()
+
+function c() {
+    return map([6, 3], function(daysSince) {
+        return this.do({
+            x: 'x',
+            daysAgo: daysSince
+        })
+    })
+}
+
+c()

--- a/test/tests/index.js
+++ b/test/tests/index.js
@@ -31,6 +31,11 @@ describe('testing eslint configuration', function() {
          */
         const failureCases = [
             {
+                filename: 'arrowReturnNewLine.js',
+                rulename: 'implicit-arrow-linebreak',
+                line: 9
+            },
+            {
                 filename: 'indentMemberExpression.js',
                 rulename: 'indent',
                 line: [11, 12, 13]


### PR DESCRIPTION
Fixes #29 