### PR TITLE
Forbid comma operator in most cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,6 +115,7 @@ module.exports = {
             2,
             "always"
         ],
+        "no-sequences": 2,
         "no-shadow-restricted-names": 2,
         "no-spaced-func": 2,
         "no-unsafe-negation": 2,


### PR DESCRIPTION
Prevents use of the comma operator except inside the condition of a `for` loop or when the sequence of expressions is wrapped in parentheses. This fixes https://github.com/TakeScoop/eslint-config-scoop/issues/41.