### PR TITLE
Update readme with instructions on how to publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ Then, add an `.eslintrc.json` file with the following:
 ```
 
 Then, try running like `$(npm bin)/eslint .`
+
+## Publishing
+
+This package is a public package that is published directly with npm: https://docs.npmjs.com/cli/publish. Note you must have the proper write permissions to publish this package. 


### PR DESCRIPTION
Gives a bit of insight as to how to publish this package, mainly to signal internal developers that this won't use our conventional publishing abstraction tool.