### PR TITLE
Add object shorthand rule for properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,6 +135,7 @@ module.exports = {
         ],
         "no-useless-return": 2,
         "no-var": 2,
+        "object-shorthand": ["error", "properties"],
         "object-curly-spacing": [
             2,
             "always",


### PR DESCRIPTION
This enforces that when object properties have the same name for the key and value, we use the object shorthand rule.

Good
```
const emails = []

callFunction({
    emails
})
```

Bad
```
const emails = []

callFunction({
    emails: emails
})
```