### PR TITLE
Add import/order HYBRID-1304

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .npmrc
 package-lock.json
+.idea

--- a/index.js
+++ b/index.js
@@ -17,6 +17,33 @@ module.exports = {
     "rules": {
         "import/no-cycle": 2,
         "import/no-unresolved": 2,
+        "import/order": [
+            "error",
+            {
+                "groups": [
+                    "builtin",
+                    "external",
+                    [
+                        "internal",
+                        "index",
+                        "sibling",
+                        "parent",
+                        "object"
+                    ]
+                ],
+                "pathGroupsExcludedImportTypes": [
+                    "builtin"
+                ],
+                "pathGroups": [
+                    {
+                        "pattern": "@scoop/**",
+                        "group": "external",
+                        "position": "after"
+                    }
+                ],
+                "newlines-between": "always"
+            }
+        ],
         "block-scoped-var": 2,
         "brace-style": [
             2,


### PR DESCRIPTION
#### Context
- https://takescoop.atlassian.net/browse/HYBRID-1304
- TLDR: task to order Node, 3rd party, then local imports ESLint configuration. 
#### Key Implementation Details

- Added import/order setup for Node, 3rd party, local import, and then others.
- Running `eslint --fix` will fail to properly format imports when side effects, or code executions occur( see [eslint-plugin-import/issues](https://github.com/benmosher/eslint-plugin-import/issues/2001)).
- I was able to confirm this by running `eslint --fix` on `agreements/src/app/server.js` and seeing formatting behavior success in one go by exluding the following import lines. Note: This was only done as a sanity check that `eslint --fix` is flaky 
```
const Metre = require('@scoop/metre').Hapi
const Relish = require('relish')() // Initialize with no options
```

ESlint happy case from agreements service's `server.js`

```
const path = require('path')

const Joi = require('joi')
const HapiRouter = require('hapi-router')
const Hapi = require('@hapi/hapi')
const Boom = require('boom')
const _ = require('lodash')
const Relish = require('relish')() // Initialize with no options

const PrivateApi = require('@scoop/private-api')
const MetreHapiHttp = require('@scoop/metre-hapi-http')
const MetreHapiProcess = require('@scoop/metre-hapi-process')
const MetreKnex = require('@scoop/metre-knex')
const MetreProcess = require('@scoop/metre-process')
const Metre = require('@scoop/metre').Hapi
const logger = require('@scoop/logger')
const HapiLager = require('@scoop/hapi-lager')

const config = require('./config')
const AgreementsCache = require('./lib/AgreementsCache')
const bookshelf = require('./lib/bookshelf')
require('./lib/registerBookshelfModels')
```


Once this CR is merged I will move on to another service and test how the formatting behavior functions. Might have to provide a revision if text wrapping seen in groups is considered excessive. 

