### PR TITLE
8.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,8 @@ jobs:
       - checkout
       - artifactory/install
       - artifactory/configure
-      - artifactory/npm-auth
+      - artifactory/npm-auth:
+          scope: scoop
       - run: npm publish
 
 workflows:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoop/eslint-config-scoop",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Scoop's custom eslint configuration",
   "engines": {
     "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@scoop/eslint-config-scoop",
-  "version": "7.0.1",
+  "version": "8.0.0",
   "description": "Scoop's custom eslint configuration",
   "engines": {
     "node": ">=12"


### PR DESCRIPTION
#### Context 

Fix unsuccessful publishing 404 error going to registry instead of artifactory seen in this [Ci event](https://app.circleci.com/pipelines/github/TakeScoop/eslint-config-scoop/40/workflows/54df10bc-fd07-45f1-93c9-f9d28ae587e7/jobs/149)

#### Solution 

Update `scope: scoop` parameter under `artifactory/npm-auth` similar to implementation seen in agreements service [CircleCi Config ](https://github.com/TakeScoop/agreements/blob/75cbca33620551dbb1a1baba874957f396014412/.circleci/config.yml#L105)