### PR TITLE
Add config pattern to pathGroups

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,11 @@ module.exports = {
                         "pattern": "@scoop/**",
                         "group": "external",
                         "position": "after"
+                    },
+                    {
+                        "pattern": ".*/config",
+                        "group": "builtin",
+                        "position": "before"
                     }
                 ],
                 "newlines-between": "always"
@@ -132,6 +137,7 @@ module.exports = {
         ],
         "no-multi-str": 2,
         "no-new-object": 2,
+        "no-prototype-builtins": 0,
         "no-restricted-syntax": [
             2,
             {


### PR DESCRIPTION
#### Context

Resolve ESLint complaining about `.config` import living at the top of the file. 

#### Change

Added another pattern for config path to [pathgroups](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md#pathgroups-array-of-objects). 

#### Testing 

Locally npm installed `eslint-config-scoop` and ran it against [agreements](https://github.com/TakeScoop/agreements), [cosmos](https://github.com/TakeScoop/cosmos), and [api](https://github.com/TakeScoop/api) reops. 